### PR TITLE
Replace working_directory parameter of CircleCI with my own namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
  build:
   # Variable expansion in working_directory not supported at this time
   # You will need to modify the code below to reflect your github account/repo setup
-  working_directory: /go/src/github.com/Securing-DevOps/invoicer-chapter2
+  working_directory: /go/src/github.com/khir19/invoicer-chapter2
   docker:
    - image: circleci/golang:1.10
   steps:


### PR DESCRIPTION
Replaced the `working_directory` parameter in `.circle-ci/config.yml` from `/go/src/github.com/Securing-DevOps/invoicer-chapter2` to `/go/src/github.com/khir19/invoicer-chapter2`.